### PR TITLE
Set line endings to force LF for docker compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set
+* text eol=lf


### PR DESCRIPTION
### ⚙️ Summary

This PR sets `.gitattributes` to force LF mode on text files during git checkout.

Fixes #5